### PR TITLE
Feature/esmf remapping util supergrid

### DIFF
--- a/APPLICATIONS.md
+++ b/APPLICATIONS.md
@@ -1,8 +1,15 @@
 # Applications
 
-The following sections describe the supported applications.
+The following sections describe the supported applications. Users
+should note that when running in a shell (i.e., not in the provided
+Docker container), the following should be done before invoking any of
+the provided applications.
 
-### Gridspec
+~~~
+user@host:$ export PYTHONPATH=/path/to/ufs_pyutils/:/path/to/ufs_tools/ush:$PYTHONPATH
+~~~
+
+## Gridspec
 
 The `gridspec` application provides an interface for generating
 [gridspec](https://arxiv.org/pdf/1911.08638.pdf) formatted
@@ -21,3 +28,16 @@ file containing the directives to define the gridspec format for the
 specified grid-spacing resolution and projection. An example
 YAML-formatted configuration file may be found
 [here](./parm/gridspec/gridspec.yaml).
+
+If choosing to launch the application within the available Docker
+container, do as follows.
+
+~~~
+user@host:$ docker container run -v /path/to/ufs_tools:/ufs_tools -v /path/to/run:/run run -it ubuntu20.04-miniconda_ufs_pyutils.ufs_tools:latest
+user@host:$ export PYTHONPATH=/ufs_tools/ush:$PYTHONPATH
+user@host:$ cd /ufs_tools/scripts
+user@host:$ python compute_gridspec.py --yaml_file=/path/to/gridspec/yaml
+~~~
+
+Note that the `yaml_file` attribute path is relative to the Docker
+container directory tree.

--- a/APPLICATIONS.md
+++ b/APPLICATIONS.md
@@ -15,7 +15,7 @@ YAML-formatted configurtaion files, must be defined relative to the
 Docker container directory tree. See the examples throughout for
 additional detail.
 
-## Gridspec
+## GridSpec
 
 The `gridspec` application provides an interface for generating
 [gridspec](https://arxiv.org/pdf/1911.08638.pdf) formatted
@@ -47,3 +47,8 @@ user@host:$ python compute_gridspec.py --yaml_file=/path/to/gridspec/yaml
 
 Note that the `yaml_file` attribute path is relative to the Docker
 container directory tree.
+
+#
+
+Please direct questions to [Henry
+R. Winterbottom](mailto:henry.winterbottom@noaa.gov?subject=[ufs_tools])

--- a/APPLICATIONS.md
+++ b/APPLICATIONS.md
@@ -9,6 +9,12 @@ the provided applications.
 user@host:$ export PYTHONPATH=/path/to/ufs_pyutils/:/path/to/ufs_tools/ush:$PYTHONPATH
 ~~~
 
+When invoking any of the provided applications within the provided
+Docker container all paths, including those within the respective
+YAML-formatted configurtaion files, must be defined relative to the
+Docker container directory tree. See the examples throughout for
+additional detail.
+
 ## Gridspec
 
 The `gridspec` application provides an interface for generating

--- a/APPLICATIONS.md
+++ b/APPLICATIONS.md
@@ -1,0 +1,23 @@
+# Applications
+
+The following sections describe the supported applications.
+
+### Gridspec
+
+The `gridspec` application provides an interface for generating
+[gridspec](https://arxiv.org/pdf/1911.08638.pdf) formatted
+grids. Grids of this format are utilized by the various remapping
+applications.
+
+To launch the application in the user shell, do as follows.
+
+~~~
+user@host:$ cd scripts/
+user@host:$ python compute_gridspec.py --yaml_file /path/to/gridspec/yaml
+~~~
+
+In the above example, the `yaml_file` attribute is a YAML-formatted
+file containing the directives to define the gridspec format for the
+specified grid-spacing resolution and projection. An example
+YAML-formatted configuration file may be found
+[here](./parm/gridspec/gridspec.yaml).

--- a/README.md
+++ b/README.md
@@ -49,3 +49,8 @@ follow those listed below.
 
 - `hotfix/user_branch_name`: Bug-type fixes which require immediate attention to fix issues that compromise the integrity of the respective application(s). 
 
+# Applications
+
+The following sections describe the supported applications provided
+within this repository.
+

--- a/README.md
+++ b/README.md
@@ -34,6 +34,9 @@ obtain the entire system, do as follows.
 user@host:$ git clone https://github.com/HenryWinterbottom-NOAA/ufs_tools
 ~~~
 
+A description of the respective applications may be found
+[here](./APPLICATIONS.md).
+
 # Forking
 
 If a user wishes to contribute modifications done within their
@@ -48,9 +51,4 @@ follow those listed below.
 - `fix/user_branch_name`: Bug-type fixes for the application(s) that do not require immediate attention.
 
 - `hotfix/user_branch_name`: Bug-type fixes which require immediate attention to fix issues that compromise the integrity of the respective application(s). 
-
-# Applications
-
-The following sections describe the supported applications provided
-within this repository.
 

--- a/parm/gridspec/gridspec.yaml
+++ b/parm/gridspec/gridspec.yaml
@@ -1,0 +1,53 @@
+# Define the netCDF-formatted output file to contain the gridspec
+# reduced-grid attributes.
+output_netcdf: /run/gridspec.tripolar.0p25.nc
+
+# ----
+
+# Define the Arakawa-type grid; a complete list of Arakawa-type grids
+# can be found here: https://tinyurl.com/arakawa-type-grids
+grid_type: C
+
+# ----
+
+# Define the latitude information attributes.
+latitude:
+
+     # Define the path to the netCDF-formatted file containing
+     # supergrid respective geographical coordinate values.
+     ncfile: /run/mom6_cice_grids/0p25/ocean_hgrid.nc
+
+     # Define the zonal-coordinate dimension name for the respective
+     # geographical coordinate variable.
+     ncxdim: nx
+
+     # Define the meridional-coordinate dimension name for the
+     # respective geographical coordinate variable.
+     ncydim: ny
+
+     # Define the netCDF-formatted file variable name for the
+     # respective geographical coordinate.
+     ncvarname: y
+
+# ----
+     
+# Define the longitude information attributes.
+longitude:
+
+     # Define the path to the netCDF-formatted file containing
+     # supergrid respective geographical coordinate values.
+     ncfile: /run/mom6_cice_grids/0p25/ocean_hgrid.nc
+
+     # Define the zonal-coordinate dimension name for the respective
+     # geographical coordinate variable.
+     ncxdim: nx
+
+     # Define the meridional-coordinate dimension name for the
+     # respective geographical coordinate variable.
+     ncydim: ny
+
+     # Define the netCDF-formatted file variable name for the
+     # respective geographical coordinate.
+     ncvarname: x
+     
+

--- a/scripts/compute_gridspec.py
+++ b/scripts/compute_gridspec.py
@@ -1,0 +1,123 @@
+# =========================================================================
+
+# Script: scripts/run_gridspec.py
+
+# Author: Henry R. Winterbottom
+
+# Email: henry.winterbottom@noaa.gov
+
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the respective public license published by the
+# Free Software Foundation and included with the repository within
+# which this application is contained.
+
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+
+# =========================================================================
+
+"""
+
+Author(s)
+---------
+
+    Henry R. Winterbottom; 07 February 2023
+
+History
+-------
+
+    2023-02-07: Henry Winterbottom -- Initial implementation.
+
+"""
+
+# ----
+
+from dataclasses import dataclass
+import os
+import time
+
+from exceptions import GridSpecError
+from gridspec.arakawa_c import ArakawaC
+
+from utils.arguments_interface import Arguments
+from utils.logger_interface import Logger
+
+# ----
+
+__author__ = "Henry R. Winterbottom"
+__maintainer__ = "Henry R. Winterbottom"
+__email__ = "henry.winterbottom@noaa.gov"
+
+# ----
+
+# Specify whether to evaluate the format for the respective parameter
+# values.
+EVAL_SCHEMA = True
+
+# Define the schema attributes.
+CLS_SCHEMA = {
+    "yaml_file": str
+}
+
+# ----
+
+
+@dataclass
+class GridSpecDriver:
+    """
+
+
+    """
+
+    def __init__(self, options_obj: object):
+        """ 
+
+        """
+
+        # Define the base-class attributes.
+        self.options_obj = options_obj
+        self.gridspec = ArakawaC(options_obj=self.options_obj)
+
+    def run(self):
+        """ """
+        self.gridspec.run()
+
+
+# ----
+
+
+def main():
+    """
+    Description
+    -----------
+
+    This is the driver-level function to invoke the tasks within this
+    script.
+
+    """
+
+    # Collect the command line arguments.
+    script_name = os.path.basename(__file__)
+    start_time = time.time()
+    msg = f"Beginning application {script_name}."
+    Logger().info(msg=msg)
+    options_obj = Arguments().run(eval_schema=EVAL_SCHEMA, cls_schema=CLS_SCHEMA)
+
+    # Launch the task.
+    task = GridSpecDriver(options_obj=options_obj)
+    task.run()
+
+    stop_time = time.time()
+    msg = f"Completed application {script_name}."
+    Logger().info(msg=msg)
+    total_time = stop_time - start_time
+    msg = f"Total Elapsed Time: {total_time} seconds."
+    Logger().info(msg=msg)
+
+
+# ----
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/compute_gridspec.py
+++ b/scripts/compute_gridspec.py
@@ -18,6 +18,51 @@
 # =========================================================================
 
 """
+Script
+------
+
+    compute_gridspec.py
+
+Description
+-----------
+
+    This script is the driver script for gridspec-formatted grid
+    computations and creations.
+
+Classes
+-------
+
+    GridSpec(options_obj)
+
+        This is the base-class object for all gridspec applications.
+
+Functions
+---------
+
+    main()
+
+        This is the driver-level function to invoke the tasks within
+        this script.
+
+Usage
+-----
+
+    user@host:$ python compute_gridspec.py --yaml_file /path/to/yaml_file
+
+Parameters
+----------
+
+    yaml_file: str
+
+        A Python string specifying the path to the YAML-formatted
+        configuration file for the gridspec application.
+
+        --yaml_file /path/to/yaml/file or -yaml_file /path/to/yaml/file
+
+Requirements
+------------
+
+- ufs_pytils; https://github.com/HenryWinterbottom-NOAA/ufs_pyutils
 
 Author(s)
 ---------
@@ -33,13 +78,11 @@ History
 
 # ----
 
-from dataclasses import dataclass
 import os
 import time
+from dataclasses import dataclass
 
-from exceptions import GridSpecError
 from gridspec.arakawa_c import ArakawaC
-
 from utils.arguments_interface import Arguments
 from utils.logger_interface import Logger
 
@@ -56,31 +99,47 @@ __email__ = "henry.winterbottom@noaa.gov"
 EVAL_SCHEMA = True
 
 # Define the schema attributes.
-CLS_SCHEMA = {
-    "yaml_file": str
-}
+CLS_SCHEMA = {"yaml_file": str}
 
 # ----
 
 
 @dataclass
-class GridSpecDriver:
+class GridSpec:
     """
+    Description
+    -----------
 
+    This is the base-class object for all gridspec applications.
+
+    Parameters
+    ----------
+
+    options_obj: object
+
+        A Python object containing the command line argument
+        attributes.
 
     """
 
     def __init__(self, options_obj: object):
-        """ 
-
-        """
+        """ """
 
         # Define the base-class attributes.
         self.options_obj = options_obj
         self.gridspec = ArakawaC(options_obj=self.options_obj)
 
     def run(self):
-        """ """
+        """
+        Description
+        -----------
+
+        This method performs the following tasks:
+
+        (1) Executes the gridspec application to compute and output
+            the gridspec-formatted file.
+
+        """
         self.gridspec.run()
 
 
@@ -105,7 +164,7 @@ def main():
     options_obj = Arguments().run(eval_schema=EVAL_SCHEMA, cls_schema=CLS_SCHEMA)
 
     # Launch the task.
-    task = GridSpecDriver(options_obj=options_obj)
+    task = GridSpec(options_obj=options_obj)
     task.run()
 
     stop_time = time.time()

--- a/ush/exceptions.py
+++ b/ush/exceptions.py
@@ -31,11 +31,20 @@ Description
 Classes
 -------
 
+    ESMFRemappingError()
+
+        This is the base-class for exceptions encountered within the
+        ush/esmf_remapping module; it is a sub-class of Error. 
+
+    GridSpecError()
+
+        This is the base-class for exceptions encountered within the
+        ush/gridspec module; it is a sub-class of Error.       
+
     InnovStatsComputeError()
 
         This is the base-class for exceptions encountered within the
         ush/innov_stats/compute module; it is a sub-class of Error.
-
 
 Author(s)
 ---------
@@ -57,6 +66,8 @@ from utils.error_interface import Error
 
 # Define all available attributes.
 __all__ = [
+    "ESMFRemappingError",
+    "GridSpecError",
     "InnovStatsComputeError"
 ]
 
@@ -65,6 +76,32 @@ __all__ = [
 __author__ = "Henry R. Winterbottom"
 __maintainer__ = "Henry R. Winterbottom"
 __email__ = "henry.winterbottom@noaa.gov"
+
+# ----
+
+
+class ESMFRemappingError(Error):
+    """
+    Description
+    -----------
+
+    This is the base-class for exceptions encountered within the
+    ush/esmf_remapping module; it is a sub-class of Error.
+
+    """
+
+# ----
+
+
+class GridSpecError(Error):
+    """
+    Description
+    -----------
+
+    This is the base-class for exceptions encountered within the
+    ush/gridspec module; it is a sub-class of Error.
+
+    """
 
 # ----
 

--- a/ush/exceptions.py
+++ b/ush/exceptions.py
@@ -34,12 +34,12 @@ Classes
     ESMFRemappingError()
 
         This is the base-class for exceptions encountered within the
-        ush/esmf_remapping module; it is a sub-class of Error. 
+        ush/esmf_remapping module; it is a sub-class of Error.
 
     GridSpecError()
 
         This is the base-class for exceptions encountered within the
-        ush/gridspec module; it is a sub-class of Error.       
+        ush/gridspec module; it is a sub-class of Error.
 
     InnovStatsComputeError()
 
@@ -70,11 +70,7 @@ from utils.error_interface import Error
 # ----
 
 # Define all available attributes.
-__all__ = [
-    "ESMFRemappingError",
-    "GridSpecError",
-    "InnovStatsComputeError"
-]
+__all__ = ["ESMFRemappingError", "GridSpecError", "InnovStatsComputeError"]
 
 # ----
 
@@ -95,6 +91,7 @@ class ESMFRemappingError(Error):
 
     """
 
+
 # ----
 
 
@@ -107,6 +104,7 @@ class GridSpecError(Error):
     ush/gridspec module; it is a sub-class of Error.
 
     """
+
 
 # ----
 

--- a/ush/exceptions.py
+++ b/ush/exceptions.py
@@ -46,6 +46,11 @@ Classes
         This is the base-class for exceptions encountered within the
         ush/innov_stats/compute module; it is a sub-class of Error.
 
+Requirements
+------------
+
+- ufs_pytils; https://github.com/HenryWinterbottom-NOAA/ufs_pyutils
+
 Author(s)
 ---------
 

--- a/ush/gridspec/__init__.py
+++ b/ush/gridspec/__init__.py
@@ -18,24 +18,56 @@
 # =========================================================================
 
 """
+Module
+------
 
+    __init__.py
 
+Description
+-----------
+
+    This module contains the base-class for all reduced grid
+    definitions determined by a defined supergrid structure specified
+    upon entry.
+
+Classes
+-------
+
+    GridSpec(options_obj)
+
+        This is the base-class for all reduced-grid definitions using
+        a supergrid structure specified upon input.
+
+Requirements
+------------
+
+- ufs_pytils; https://github.com/HenryWinterbottom-NOAA/ufs_pyutils
+
+Author(s)
+---------
+
+    Henry R. Winterbottom; 08 February 2023
+
+History
+-------
+
+    2023-02-08: Henry Winterbottom -- Initial implementation.
 
 """
 
 # ----
 
+# pylint: disable=too-many-instance-attributes
+
+# ----
+
 import os
+
 import numpy
-
 from confs.yaml_interface import YAML
-
 from exceptions import GridSpecError
-
-from tools import fileio_interface
-from tools import parser_interface
 from ioapps import netcdf4_interface
-
+from tools import fileio_interface, parser_interface
 from utils.logger_interface import Logger
 
 # ----
@@ -49,6 +81,19 @@ __email__ = "henry.winterbottom@noaa.gov"
 
 class GridSpec:
     """
+    Description
+    -----------
+
+    This is the base-class for all reduced-grid definitions using a
+    supergrid structure specified upon input.
+
+    Parameters
+    ----------
+
+    options_obj: object
+
+        A Python object containing the command line argument
+        attributes.
 
     """
 
@@ -68,18 +113,50 @@ class GridSpec:
 
         self.yaml_dict = YAML().read_yaml(yaml_file=self.yaml_file)
 
-        self.grid_attr_list = ["latitude", "longitude", "mask", "topography"]
+        self.grid_attr_list = ["latitude", "longitude"]
 
         self.reduce_grid_obj = parser_interface.object_define()
-        self.reduce_grid_list = ["qlat", "qlon", "tlat", "tlon", "ulat", "ulon",
-                                 "vlat", "vlon"
-                                 ]
+        self.reduce_grid_list = [
+            "qlat",
+            "qlon",
+            "tlat",
+            "tlon",
+            "ulat",
+            "ulon",
+            "vlat",
+            "vlon",
+        ]
 
-        (self.grids_obj, self.ncdim_obj, self.ncvar_obj) = \
-            [parser_interface.object_define() for idx in range(3)]
+        (self.grids_obj, self.ncdim_obj, self.ncvar_obj) = [
+            parser_interface.object_define() for idx in range(3)
+        ]
 
-    def read_ncfile(self):
-        """ """
+    def read_ncfile(self) -> None:
+        """
+        Description
+        -----------
+
+        This method parses the specified netCDF-formatted file path
+        containing the supergrid structure; the supergrid structure is
+        encapsulated within the base-class object grids_obj.
+
+        Raises
+        ------
+
+        GridSpecError:
+
+            * raised if the specified netCDF attribute can not be
+              determined for the grid attribute defined within the
+              experiment configuration file.
+
+            * raised if a specified mandatory attribute cannot be
+              determined from the experiment configuration file; see
+              base-class attribute grid_attr_list.
+
+            * raised if the specified netCDF-formatted file path does
+              not exist upon entry.
+
+        """
 
         # Define the netCDF attributes for the grid variables.
         nc_attr_list = ["ncfile", "ncvarname", "ncxdim", "ncydim"]
@@ -89,11 +166,14 @@ class GridSpec:
             # Collect the YAML attributes for the respective grid
             # attribute; proceed accordingly.
             grid_dict = parser_interface.dict_key_value(
-                dict_in=self.yaml_dict, key=grid_attr, force=True)
+                dict_in=self.yaml_dict, key=grid_attr, force=True
+            )
             if grid_dict is None:
-                msg = (f"The attributes for grid attribute {grid_attr} could not "
-                       f"be determined from configurtion file {self.yaml_file}. "
-                       "Aborting!!!")
+                msg = (
+                    f"The attributes for grid attribute {grid_attr} could not "
+                    f"be determined from configurtion file {self.yaml_file}. "
+                    "Aborting!!!"
+                )
                 raise GridSpecError(msg=msg)
 
             # Collect the netCDF attributes; proceed accordingly.
@@ -101,39 +181,48 @@ class GridSpec:
 
             for nc_attr in nc_attr_list:
                 value = parser_interface.dict_key_value(
-                    dict_in=grid_dict, key=nc_attr, force=True, no_split=True)
+                    dict_in=grid_dict, key=nc_attr, force=True, no_split=True
+                )
                 if value is None:
-                    msg = (f"netCDF attribute {nc_attr} could not be determined for "
-                           f"grid {grid_attr} in configurtion file {self.yaml_file}. "
-                           "Aborting!!!"
-                           )
+                    msg = (
+                        f"netCDF attribute {nc_attr} could not be determined for "
+                        f"grid {grid_attr} in configurtion file {self.yaml_file}. "
+                        "Aborting!!!"
+                    )
                     raise GridSpecError(msg=msg)
 
                 nc_obj = parser_interface.object_setattr(
-                    object_in=nc_obj, key=nc_attr, value=value)
+                    object_in=nc_obj, key=nc_attr, value=value
+                )
 
             # Check that the netCDF-formatted file path exists;
             # proceed accordingly.
             fileexist = fileio_interface.fileexist(path=nc_obj.ncfile)
             if not fileexist:
-                msg = (f"The netCDF-formatted file path {nc_obj.ncfile} does not exist. "
-                       "Aborting!!!")
+                msg = (
+                    f"The netCDF-formatted file path {nc_obj.ncfile} does not exist. "
+                    "Aborting!!!"
+                )
                 raise GridSpecError(msg=msg)
 
             # Collect the netCDF variable values.
-            msg = (f"Collecting grid variable {grid_attr} attributes from netCDF-formatted "
-                   f"file path {nc_obj.ncfile}."
-                   )
+            msg = (
+                f"Collecting grid variable {grid_attr} attributes from netCDF-formatted "
+                f"file path {nc_obj.ncfile}."
+            )
             self.logger.info(msg=msg)
-            ncvalues = netcdf4_interface.ncreadvar(ncfile=nc_obj.ncfile,
-                                                   ncvarname=nc_obj.ncvarname)
+            ncvalues = netcdf4_interface.ncreadvar(
+                ncfile=nc_obj.ncfile, ncvarname=nc_obj.ncvarname
+            )
             nc_obj = parser_interface.object_setattr(
-                object_in=nc_obj, key="ncvalues", value=ncvalues)
+                object_in=nc_obj, key="ncvalues", value=ncvalues
+            )
 
             self.grids_obj = parser_interface.object_setattr(
-                object_in=self.grids_obj, key=grid_attr, value=nc_obj)
+                object_in=self.grids_obj, key=grid_attr, value=nc_obj
+            )
 
-    def update_ncvar(self, ncvar_dict: dict, ncvar_obj: object) -> None:
+    def update_ncvar(self, ncvar_dict: dict, ncvar_obj: object) -> object:
         """
         Description
         -----------
@@ -148,6 +237,23 @@ class GridSpec:
 
             A Python dictionary containing the respective netCDF
             variable attributes.
+
+        ncvar_obj: object
+
+            A Python object containing the netCDF variable object;
+            this object is the accumulated netCDF variable attributes
+            to be written to the specified netCDF-formatted output
+            file path.
+
+        Returns
+        -------
+
+        ncvar_obj: object
+
+            A Python object containing the updated netCDF variable
+            object; this object is the accumulated netCDF variable
+            attributes to be written to the specified netCDF-formatted
+            output file path.
 
         """
 
@@ -169,30 +275,51 @@ class GridSpec:
         return ncvar_obj
 
     def write_ncfile(self) -> None:
-        """ """
+        """
+        Description
+        -----------
+
+        This method writes the netCDF-formatted output file path using
+        the attributes contained within the base-class attributes
+        ncdim_obj and ncvar_obj; if a netCDF-formatted output file
+        path has not been specified the reduced grid definitions to
+        the file gridspec.nc in the run-time directory tree path.
+
+        """
 
         # Define the netCDF-formatted output path; proceed
         # accordingly.
         ncfile = parser_interface.dict_key_value(
-            dict_in=self.yaml_dict, key="output_netcdf", force=True,
-            no_split=True)
+            dict_in=self.yaml_dict, key="output_netcdf", force=True, no_split=True
+        )
         if ncfile is None:
 
             # Define a generic netCDF-formatted file output path.
             ncfile = os.path.join(os.getcwd(), "gridspec.nc")
 
-            msg = (f"The experiment configuration file {self.yaml_file} does not "
-                   f"specify an output file name; setting to {ncfile}."
-                   )
-            self.logger.warn()
+            msg = (
+                f"The experiment configuration file {self.yaml_file} does not "
+                f"specify an output file name; setting to {ncfile}."
+            )
+            self.logger.warn(msg=msg)
 
         # Write the netCDF-formatted file.
-        msg = (f"Writing reduced to path {ncfile}.")
+        msg = f"Writing reduced to path {ncfile}."
         self.logger.info(msg=msg)
-        netcdf4_interface.ncwrite(ncfile=ncfile, ncdim_obj=self.ncdim_obj,
-                                  ncvar_obj=self.ncvar_obj, ncfrmt="NETCDF4")
+        netcdf4_interface.ncwrite(
+            ncfile=ncfile,
+            ncdim_obj=self.ncdim_obj,
+            ncvar_obj=self.ncvar_obj,
+            ncfrmt="NETCDF4",
+        )
 
     def run(self) -> None:
         """
+        Description
+        -----------
+
+        This method is generic and used to run the methods for the
+        respective calling class (i.e., GridSpec sub-class)
+        applications.
 
         """

--- a/ush/gridspec/__init__.py
+++ b/ush/gridspec/__init__.py
@@ -1,0 +1,198 @@
+# =========================================================================
+
+# Module: ush/gridspec/__init__.py
+
+# Author: Henry R. Winterbottom
+
+# Email: henry.winterbottom@noaa.gov
+
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the respective public license published by the
+# Free Software Foundation and included with the repository within
+# which this application is contained.
+
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+
+# =========================================================================
+
+"""
+
+
+
+"""
+
+# ----
+
+import os
+import numpy
+
+from confs.yaml_interface import YAML
+
+from exceptions import GridSpecError
+
+from tools import fileio_interface
+from tools import parser_interface
+from ioapps import netcdf4_interface
+
+from utils.logger_interface import Logger
+
+# ----
+
+__author__ = "Henry R. Winterbottom"
+__maintainer__ = "Henry R. Winterbottom"
+__email__ = "henry.winterbottom@noaa.gov"
+
+# ----
+
+
+class GridSpec:
+    """
+
+    """
+
+    def __init__(self, options_obj: object):
+        """
+        Description
+        -----------
+
+        Creates a new GridSpec object.
+
+        """
+
+        # Define base-class attributes.
+        self.options_obj = options_obj
+        self.logger = Logger()
+        self.yaml_file = self.options_obj.yaml_file
+
+        self.yaml_dict = YAML().read_yaml(yaml_file=self.yaml_file)
+
+        self.grid_attr_list = ["latitude", "longitude", "mask", "topography"]
+
+        self.reduce_grid_obj = parser_interface.object_define()
+        self.reduce_grid_list = ["qlat", "qlon", "tlat", "tlon", "ulat", "ulon",
+                                 "vlat", "vlon"
+                                 ]
+
+        (self.grids_obj, self.ncdim_obj, self.ncvar_obj) = \
+            [parser_interface.object_define() for idx in range(3)]
+
+    def read_ncfile(self):
+        """ """
+
+        # Define the netCDF attributes for the grid variables.
+        nc_attr_list = ["ncfile", "ncvarname", "ncxdim", "ncydim"]
+
+        for grid_attr in self.grid_attr_list:
+
+            # Collect the YAML attributes for the respective grid
+            # attribute; proceed accordingly.
+            grid_dict = parser_interface.dict_key_value(
+                dict_in=self.yaml_dict, key=grid_attr, force=True)
+            if grid_dict is None:
+                msg = (f"The attributes for grid attribute {grid_attr} could not "
+                       f"be determined from configurtion file {self.yaml_file}. "
+                       "Aborting!!!")
+                raise GridSpecError(msg=msg)
+
+            # Collect the netCDF attributes; proceed accordingly.
+            nc_obj = parser_interface.object_define()
+
+            for nc_attr in nc_attr_list:
+                value = parser_interface.dict_key_value(
+                    dict_in=grid_dict, key=nc_attr, force=True, no_split=True)
+                if value is None:
+                    msg = (f"netCDF attribute {nc_attr} could not be determined for "
+                           f"grid {grid_attr} in configurtion file {self.yaml_file}. "
+                           "Aborting!!!"
+                           )
+                    raise GridSpecError(msg=msg)
+
+                nc_obj = parser_interface.object_setattr(
+                    object_in=nc_obj, key=nc_attr, value=value)
+
+            # Check that the netCDF-formatted file path exists;
+            # proceed accordingly.
+            fileexist = fileio_interface.fileexist(path=nc_obj.ncfile)
+            if not fileexist:
+                msg = (f"The netCDF-formatted file path {nc_obj.ncfile} does not exist. "
+                       "Aborting!!!")
+                raise GridSpecError(msg=msg)
+
+            # Collect the netCDF variable values.
+            msg = (f"Collecting grid variable {grid_attr} attributes from netCDF-formatted "
+                   f"file path {nc_obj.ncfile}."
+                   )
+            self.logger.info(msg=msg)
+            ncvalues = netcdf4_interface.ncreadvar(ncfile=nc_obj.ncfile,
+                                                   ncvarname=nc_obj.ncvarname)
+            nc_obj = parser_interface.object_setattr(
+                object_in=nc_obj, key="ncvalues", value=ncvalues)
+
+            self.grids_obj = parser_interface.object_setattr(
+                object_in=self.grids_obj, key=grid_attr, value=nc_obj)
+
+    def update_ncvar(self, ncvar_dict: dict, ncvar_obj: object) -> None:
+        """
+        Description
+        -----------
+
+        This method updates the base-class netCDF variable object
+        (ncvar_obj).
+
+        Parameters
+        ----------
+
+        ncvar_dict: dict
+
+            A Python dictionary containing the respective netCDF
+            variable attributes.
+
+        """
+
+        # Loop through all netCDF variable attributes and update the
+        # base-class netCDF variable object.
+        for key in ncvar_dict.keys():
+            dict_in = {}
+            for item in ncvar_dict[key].keys():
+                value = parser_interface.dict_key_value(
+                    dict_in=ncvar_dict[key], key=item, no_split=True
+                )
+                dict_in[item] = value
+
+            # Update the netCDF variable object.
+            ncvar_obj = parser_interface.object_setattr(
+                object_in=ncvar_obj, key=key, value=dict_in
+            )
+
+        return ncvar_obj
+
+    def write_ncfile(self) -> None:
+        """ """
+
+        # Define the netCDF-formatted output path; proceed
+        # accordingly.
+        ncfile = parser_interface.dict_key_value(
+            dict_in=self.yaml_dict, key="output_netcdf", force=True,
+            no_split=True)
+        if ncfile is None:
+
+            # Define a generic netCDF-formatted file output path.
+            ncfile = os.path.join(os.getcwd(), "gridspec.nc")
+
+            msg = (f"The experiment configuration file {self.yaml_file} does not "
+                   f"specify an output file name; setting to {ncfile}."
+                   )
+            self.logger.warn()
+
+        # Write the netCDF-formatted file.
+        msg = (f"Writing reduced to path {ncfile}.")
+        self.logger.info(msg=msg)
+        netcdf4_interface.ncwrite(ncfile=ncfile, ncdim_obj=self.ncdim_obj,
+                                  ncvar_obj=self.ncvar_obj, ncfrmt="NETCDF4")
+
+    def run(self) -> None:
+        """
+
+        """

--- a/ush/gridspec/__init__.py
+++ b/ush/gridspec/__init__.py
@@ -67,7 +67,8 @@ import numpy
 from confs.yaml_interface import YAML
 from exceptions import GridSpecError
 from ioapps import netcdf4_interface
-from tools import fileio_interface, parser_interface
+from tools import datetime_interface, fileio_interface, parser_interface
+from utils import timestamp_interface
 from utils.logger_interface import Logger
 
 # ----
@@ -303,6 +304,13 @@ class GridSpec:
             )
             self.logger.warn(msg=msg)
 
+        # Define the global attributes for the netCDF-formatted file.
+        glbattrs_dict = {
+            "_FillValue": numpy.nan,
+            "date": datetime_interface.current_date(timestamp_interface.INFO),
+            "created": str(parser_interface.enviro_get(envvar="HOSTNAME")),
+        }
+
         # Write the netCDF-formatted file.
         msg = f"Writing reduced to path {ncfile}."
         self.logger.info(msg=msg)
@@ -311,6 +319,7 @@ class GridSpec:
             ncdim_obj=self.ncdim_obj,
             ncvar_obj=self.ncvar_obj,
             ncfrmt="NETCDF4",
+            glbattrs_dict=glbattrs_dict,
         )
 
     def run(self) -> None:

--- a/ush/gridspec/arakawa_c.py
+++ b/ush/gridspec/arakawa_c.py
@@ -1,6 +1,6 @@
 # =========================================================================
 
-# Module: ush/gridspec/arkawa_c.py
+# Module: ush/gridspec/arakawa_c.py
 
 # Author: Henry R. Winterbottom
 
@@ -18,16 +18,54 @@
 # =========================================================================
 
 """
+Module
+------
+
+    arakawa_c.py
+
+Description
+-----------
+
+    This module contains the base-class for all Arakawa-C type reduced
+    grid projections from a specified supergrid structure.
+
+Classes
+-------
+
+    ArakawaC(options_obj)
+
+        This is the base-class object for all Arakawa-C type reduced
+        grid projections generated from a specified supergrid
+        structure; it is a sub-class of GridSpec.
+
+Requirements
+------------
+
+- ufs_pytils; https://github.com/HenryWinterbottom-NOAA/ufs_pyutils
+
+Author(s)
+---------
+
+    Henry R. Winterbottom; 08 February 2023
+
+History
+-------
+
+    2023-02-08: Henry Winterbottom -- Initial implementation.
 
 """
 
 # ----
 
-import numpy
+# pylint: disable=eval-used
+# pylint: disable=invalid-name
+# pylint: disable=unused-variable
 
-from tools import parser_interface
+# ----
 
 from exceptions import GridSpecError
+from tools import parser_interface
+
 from gridspec import GridSpec
 
 # ----
@@ -41,6 +79,20 @@ __email__ = "henry.winterbottom@noaa.gov"
 
 class ArakawaC(GridSpec):
     """
+    Description
+    -----------
+
+    This is the base-class object for all Arakawa-C type reduced grid
+    projections generated from a specified supergrid structure; it is
+    a sub-class of GridSpec.
+
+    Parameters
+    ----------
+
+    options_obj: object
+
+        A Python object containing the command line argument
+        attributes.
 
     """
 
@@ -57,32 +109,47 @@ class ArakawaC(GridSpec):
         super().__init__(options_obj=options_obj)
 
         # Define the reduced grid variable attributes.
-        self.reduce_grid_dict = {"qlat": ["nyp", "nxp"],
-                                 "qlon": ["nyp", "nxp"],
-                                 "tlat": ["ny", "nx"],
-                                 "tlon": ["ny", "nx"],
-                                 "ulat": ["ny", "nxp"],
-                                 "ulon": ["ny", "nxp"],
-                                 "vlat": ["nyp", "nx"],
-                                 "vlon": ["nyp", "nx"]
-                                 }
+        self.reduce_grid_dict = {
+            "qlat": ["nyp", "nxp"],
+            "qlon": ["nyp", "nxp"],
+            "tlat": ["ny", "nx"],
+            "tlon": ["ny", "nx"],
+            "ulat": ["ny", "nxp"],
+            "ulon": ["ny", "nxp"],
+            "vlat": ["nyp", "nx"],
+            "vlon": ["nyp", "nx"],
+        }
 
     def compute_grid(self: GridSpec) -> None:
         """
+        Description
+        -----------
+
+        This method defines the Arakawa-C type grid projection from
+        the supergrid structure collected from the specified
+        netCDF-formatted file path; the Arakawa-C grid projection is
+        encapsulated within the base-class object reduce_grid_obj upon
+        exit; the base-class netCDF-formatted output file dimension
+        attributes are defined within the ncdim_obj object upon exit.
+
         """
 
         # Define the netCDF grid-coordinate dimensions.
         nx = (self.grids_obj.mask.ncvalues.shape)[1]
         self.ncdim_obj = parser_interface.object_setattr(
-            object_in=self.ncdim_obj, key="nx", value=nx)
+            object_in=self.ncdim_obj, key="nx", value=nx
+        )
         self.ncdim_obj = parser_interface.object_setattr(
-            object_in=self.ncdim_obj, key="nxp", value=(nx + 1))
+            object_in=self.ncdim_obj, key="nxp", value=(nx + 1)
+        )
 
         ny = (self.grids_obj.mask.ncvalues.shape)[0]
         self.ncdim_obj = parser_interface.object_setattr(
-            object_in=self.ncdim_obj, key="ny", value=ny)
+            object_in=self.ncdim_obj, key="ny", value=ny
+        )
         self.ncdim_obj = parser_interface.object_setattr(
-            object_in=self.ncdim_obj, key="nyp", value=(ny + 1))
+            object_in=self.ncdim_obj, key="nyp", value=(ny + 1)
+        )
 
         # Define the grid-cell corner point geographical coordinate
         # values using the supergrid.
@@ -112,12 +179,22 @@ class ArakawaC(GridSpec):
         # Update the base-class attribute containing the reduced grid
         # attributes.
         for reduce_grid in self.reduce_grid_list:
+
             self.reduce_grid_obj = parser_interface.object_setattr(
-                object_in=self.reduce_grid_obj, key=reduce_grid,
-                value=eval(reduce_grid))
+                object_in=self.reduce_grid_obj, key=reduce_grid, value=eval(reduce_grid)
+            )
 
     def prepare_ncfile(self: GridSpec) -> None:
-        """ """
+        """
+        Description
+        -----------
+
+        This method prepares the output netCDF-formatted output file
+        containing the reduced grid attributes; the base-class
+        attributes ncvar_obj object, containing the reduced grid
+        attributes, is defined upon exit.
+
+        """
 
         # Build the object containing the reduced grid variables to be
         # written to the netCDF-formatted file path.
@@ -125,27 +202,50 @@ class ArakawaC(GridSpec):
 
             # Define the netCDF variable attributes.
             dims = parser_interface.dict_key_value(
-                dict_in=self.reduce_grid_dict, key=grid_var, force=True,
-                no_split=True)
+                dict_in=self.reduce_grid_dict, key=grid_var, force=True, no_split=True
+            )
             if dims is None:
-                msg = ("The grid dimension variable names could not be determined "
-                       f"for grid coordinate variable {grid_var}. Aborting!!!"
-                       )
+                msg = (
+                    "The grid dimension variable names could not be determined "
+                    f"for grid coordinate variable {grid_var}. Aborting!!!"
+                )
                 raise GridSpecError(msg=msg)
 
-            ncvar_dict = {grid_var: {"varname": grid_var, "dims": dims,
-                                     "type": "float64", "values":
-                                     parser_interface.object_getattr(
-                                         self.reduce_grid_obj, key=grid_var)
-                                     }
-                          }
+            ncvar_dict = {
+                grid_var: {
+                    "varname": grid_var,
+                    "dims": dims,
+                    "type": "float64",
+                    "values": parser_interface.object_getattr(
+                        self.reduce_grid_obj, key=grid_var
+                    ),
+                }
+            }
 
             # Update the base-class netCDF variable object.
-            self.ncvar_obj = self.update_ncvar(ncvar_dict=ncvar_dict,
-                                               ncvar_obj=self.ncvar_obj)
+            self.ncvar_obj = self.update_ncvar(
+                ncvar_dict=ncvar_dict, ncvar_obj=self.ncvar_obj
+            )
 
     def run(self: GridSpec) -> None:
-        """ """
+        """
+        Description
+        -----------
+
+        This method performs the following tasks:
+
+        (1) Collects the netCDF attributes describing the supergrid
+            structure from the specified file paths.
+
+        (2) Defines/computes the reduced grid as defined by the
+            supergrid structure specified upon entry.
+
+        (3) Prepares the netCDF-formatted output file strutures.
+
+        (4) Writes the netCDF-formatted output file path in accordance
+            with the experiment configuaration.
+
+        """
 
         # Collect the necessary variables from the netCDF-formatted
         # file path.

--- a/ush/gridspec/arakawa_c.py
+++ b/ush/gridspec/arakawa_c.py
@@ -1,0 +1,163 @@
+# =========================================================================
+
+# Module: ush/gridspec/arkawa_c.py
+
+# Author: Henry R. Winterbottom
+
+# Email: henry.winterbottom@noaa.gov
+
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the respective public license published by the
+# Free Software Foundation and included with the repository within
+# which this application is contained.
+
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+
+# =========================================================================
+
+"""
+
+"""
+
+# ----
+
+import numpy
+
+from tools import parser_interface
+
+from exceptions import GridSpecError
+from gridspec import GridSpec
+
+# ----
+
+__author__ = "Henry R. Winterbottom"
+__maintainer__ = "Henry R. Winterbottom"
+__email__ = "henry.winterbottom@noaa.gov"
+
+# ----
+
+
+class ArakawaC(GridSpec):
+    """
+
+    """
+
+    def __init__(self: GridSpec, options_obj: object):
+        """
+        Description
+        -----------
+
+        Creates a new ArakawaC object.
+
+        """
+
+        # Define the base-class attributes.
+        super().__init__(options_obj=options_obj)
+
+        # Define the reduced grid variable attributes.
+        self.reduce_grid_dict = {"qlat": ["nyp", "nxp"],
+                                 "qlon": ["nyp", "nxp"],
+                                 "tlat": ["ny", "nx"],
+                                 "tlon": ["ny", "nx"],
+                                 "ulat": ["ny", "nxp"],
+                                 "ulon": ["ny", "nxp"],
+                                 "vlat": ["nyp", "nx"],
+                                 "vlon": ["nyp", "nx"]
+                                 }
+
+    def compute_grid(self: GridSpec) -> None:
+        """
+        """
+
+        # Define the netCDF grid-coordinate dimensions.
+        nx = (self.grids_obj.mask.ncvalues.shape)[1]
+        self.ncdim_obj = parser_interface.object_setattr(
+            object_in=self.ncdim_obj, key="nx", value=nx)
+        self.ncdim_obj = parser_interface.object_setattr(
+            object_in=self.ncdim_obj, key="nxp", value=(nx + 1))
+
+        ny = (self.grids_obj.mask.ncvalues.shape)[0]
+        self.ncdim_obj = parser_interface.object_setattr(
+            object_in=self.ncdim_obj, key="ny", value=ny)
+        self.ncdim_obj = parser_interface.object_setattr(
+            object_in=self.ncdim_obj, key="nyp", value=(ny + 1))
+
+        # Define the grid-cell corner point geographical coordinate
+        # values using the supergrid.
+        qlat = self.grids_obj.latitude.ncvalues[::2, ::2]
+        qlon = self.grids_obj.longitude.ncvalues[::2, ::2]
+
+        # Define the mass variable geographical grid coordinate
+        # values using the supergrid.
+        tlat = self.grids_obj.latitude.ncvalues[1::2, 1::2]
+        tlon = self.grids_obj.longitude.ncvalues[1::2, 1::2]
+
+        # Define the topography grid values; these are defined at the
+        # mass variable geographical grid coordinate values of the
+        # reduced .
+        topog = self.grids_obj.topography.ncvalues[:, :]
+
+        # Define the zonal-velocity variable geographical coordinate
+        # values using the supergrid.
+        ulat = self.grids_obj.latitude.ncvalues[1::2, ::2]
+        ulon = self.grids_obj.longitude.ncvalues[1::2, ::2]
+
+        # Define the meridional-velocity variable geographical
+        # coordinate values using the supergrid.
+        vlat = self.grids_obj.latitude.ncvalues[::2, 1::2]
+        vlon = self.grids_obj.longitude.ncvalues[::2, 1::2]
+
+        # Update the base-class attribute containing the reduced grid
+        # attributes.
+        for reduce_grid in self.reduce_grid_list:
+            self.reduce_grid_obj = parser_interface.object_setattr(
+                object_in=self.reduce_grid_obj, key=reduce_grid,
+                value=eval(reduce_grid))
+
+    def prepare_ncfile(self: GridSpec) -> None:
+        """ """
+
+        # Build the object containing the reduced grid variables to be
+        # written to the netCDF-formatted file path.
+        for grid_var in list(vars(self.reduce_grid_obj).keys()):
+
+            # Define the netCDF variable attributes.
+            dims = parser_interface.dict_key_value(
+                dict_in=self.reduce_grid_dict, key=grid_var, force=True,
+                no_split=True)
+            if dims is None:
+                msg = ("The grid dimension variable names could not be determined "
+                       f"for grid coordinate variable {grid_var}. Aborting!!!"
+                       )
+                raise GridSpecError(msg=msg)
+
+            ncvar_dict = {grid_var: {"varname": grid_var, "dims": dims,
+                                     "type": "float64", "values":
+                                     parser_interface.object_getattr(
+                                         self.reduce_grid_obj, key=grid_var)
+                                     }
+                          }
+
+            # Update the base-class netCDF variable object.
+            self.ncvar_obj = self.update_ncvar(ncvar_dict=ncvar_dict,
+                                               ncvar_obj=self.ncvar_obj)
+
+    def run(self: GridSpec) -> None:
+        """ """
+
+        # Collect the necessary variables from the netCDF-formatted
+        # file path.
+        self.read_ncfile()
+
+        # Compute the values describing the respective grid-type.
+        self.compute_grid()
+
+        # Prepare the base-class attributes for the netCDF-formatted
+        # file path creation.
+        self.prepare_ncfile()
+
+        # Write the netCDF-formatted file path containing the reduced
+        # grid attributes.
+        self.write_ncfile()

--- a/ush/innov_stats/compute/__init__.py
+++ b/ush/innov_stats/compute/__init__.py
@@ -144,10 +144,10 @@ class InnovStats:
 
         # Collect the relevant information from the experiment
         # configuration.
-        self.diagsinfo_obj = parser_interface.object_define()
+        (self.diagsinfo_obj, self.levels_obj) = [
+            parser_interface.object_define() for idx in range(2)]
         self.regions_obj = self.get_regions()
         self.diagsvars = self.get_diagsinfo()
-        self.levels_obj = parser_interface.object_define()
 
     def build_database(
         self, column_frmt: str, levels_list: list = None, column_scale: float = 1.0
@@ -266,7 +266,8 @@ class InnovStats:
 
                     if levels_list is not None:
                         for level in levels_list:
-                            table_dict[column_frmt % int(level * column_scale)] = "REAL"
+                            table_dict[column_frmt %
+                                       int(level * column_scale)] = "REAL"
 
                     # Create the SQLite3 database table.
                     sqlite3_interface.create_table(
@@ -390,7 +391,8 @@ class InnovStats:
         # bottom layer interfaces for the respective level) as well as
         # the mean value for the respective interval (i.e., the layer
         # mean -- the middle of the layer).
-        levels_attr_dict = {"depth_bottom": "layer_bottom", "depth_top": "layer_top"}
+        levels_attr_dict = {
+            "depth_bottom": "layer_bottom", "depth_top": "layer_top"}
         for (levels_attr, _) in levels_attr_dict.items():
             value = parser_interface.dict_key_value(
                 dict_in=depth_levels_dict, key=levels_attr, force=True
@@ -1040,8 +1042,7 @@ class InnovStats:
         Description
         -----------
 
-        This method updates the base-class netCDF variable object
-        (ncvar_obj).
+        This method updates the netCDF variable object (ncvar_obj).
 
         Parameters
         ----------

--- a/ush/innov_stats/compute/gsi_atmos.py
+++ b/ush/innov_stats/compute/gsi_atmos.py
@@ -39,6 +39,11 @@ Classes
         Interpolation (GSI) atmosphere innovation statistics
         diagnostics; it is a sub-class of InnovStats.
 
+Requirements
+------------
+
+- ufs_pytils; https://github.com/HenryWinterbottom-NOAA/ufs_pyutils
+
 Author(s)
 ---------
 


### PR DESCRIPTION
This PR provides an application to compute/define `gridspec`-type formatted grids for the available remapping applications.

This PR currently has only been tested to define gridspec-formatted tripolar grid projections for MOM6 and CICE.